### PR TITLE
Second Middleware Required sometimes

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,6 @@ from unittest import mock
 import django.db
 import pytest
 from django.contrib.auth.models import User
-from django.test import RequestFactory
 from django.utils import timezone
 
 from token_user_visit.models import TokenUserVisit, parse_remote_addr, parse_ua_string
@@ -106,7 +105,7 @@ class TestTokenUserVisit:
     def test_save_with_token(self):
         request = mock_request()
         request.user.save()
-        request.META["HTTP_AUTHORIZATION"] = f"Bearer testtoken123456"
+        request.META["HTTP_AUTHORIZATION"] = "Bearer testtoken123456"
         timestamp = timezone.now()
         uv = TokenUserVisit.objects.build_with_token(request, timestamp)
         uv.hash = None

--- a/token_user_visit/settings.py
+++ b/token_user_visit/settings.py
@@ -54,3 +54,10 @@ DUPLICATE_LOG_LEVEL: str = getattr(
 ACTIVATE_SESSION_ONLY_RECORDING: Callable[[HttpRequest], bool] = getattr(
     settings, "TOKEN_USER_VISIT_SESSION_ACTIVATOR", lambda r: False
 )
+
+
+TOKEN_AUTHENTICATION_CLASS: type = getattr(
+    settings, "TOKEN_USER_VISIT_AUTHENTICATION_CLASS", None
+)
+
+TOKEN_KEYWORD: str = getattr(settings, "TOKEN_USER_VISIT_KEYWORD", "Bearer")


### PR DESCRIPTION
DRF's default `authtoken` does not include middleware to set `request.user` and so creating `TokenUserVisit` instances failed because they depend on the `request.user`.

Django OAuth Toolkit has middleware to set the `request.user` while the middleware is being called.

`RequestUserSetterMiddleware` can be optionally added to an app if the Auth token library being used doesn't already have it.